### PR TITLE
Vle test: add encoding size

### DIFF
--- a/exercises/variable-length-quantity/example.go
+++ b/exercises/variable-length-quantity/example.go
@@ -2,14 +2,55 @@ package variablelengthquantity
 
 // EncodeVarint returns the varint encoding of x.
 func EncodeVarint(x uint32) []byte {
-	// TODO: implement me
-	return nil
+	if x>>7 == 0 {
+		return []byte{
+			byte(x),
+		}
+	}
+
+	if x>>14 == 0 {
+		return []byte{
+			byte(0x80 | x>>7),
+			byte(127 & x),
+		}
+	}
+
+	if x>>21 == 0 {
+		return []byte{
+			byte(0x80 | x>>14),
+			byte(0x80 | x>>7),
+			byte(127 & x),
+		}
+	}
+
+	return []byte{
+		byte(0x80 | x>>21),
+		byte(0x80 | x>>14),
+		byte(0x80 | x>>7),
+		byte(127 & x),
+	}
 }
 
 // DecodeVarint reads a varint-encoded integer from the slice.
 // It returns the integer and the number of bytes consumed, or
 // zero if there is not enough.
 func DecodeVarint(buf []byte) (x uint32, n int) {
-	// TODO: implement me
-	return 0, 0
+	if len(buf) < 1 {
+		return 0, 0
+	}
+
+	if buf[0] <= 0x80 {
+		return uint32(buf[0]), 1
+	}
+
+	var b byte
+	for n, b = range buf {
+		x = x << 7
+		x |= uint32(b) & 0x7F
+		if (b & 0x80) == 0 {
+			return x, n
+		}
+	}
+
+	return x, n
 }

--- a/exercises/variable-length-quantity/variable_length_quantity_test.go
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.go
@@ -9,25 +9,30 @@ func TestEncodeDecodeVarint(t *testing.T) {
 	testCases := []struct {
 		input  []byte
 		output uint32
+		size   int
 	}{
-		0: {[]byte{0x7F}, 127},
-		1: {[]byte{0x81, 0x00}, 128},
-		2: {[]byte{0xC0, 0x00}, 8192},
-		3: {[]byte{0xFF, 0x7F}, 16383},
-		4: {[]byte{0x81, 0x80, 0x00}, 16384},
-		5: {[]byte{0xFF, 0xFF, 0x7F}, 2097151},
-		6: {[]byte{0x81, 0x80, 0x80, 0x00}, 2097152},
-		7: {[]byte{0xC0, 0x80, 0x80, 0x00}, 134217728},
-		8: {[]byte{0xFF, 0xFF, 0xFF, 0x7F}, 268435455},
+		0: {[]byte{0x7F}, 127, 1},
+		1: {[]byte{0x81, 0x00}, 128, 1},
+		2: {[]byte{0xC0, 0x00}, 8192, 1},
+		3: {[]byte{0xFF, 0x7F}, 16383, 1},
+		4: {[]byte{0x81, 0x80, 0x00}, 16384, 2},
+		5: {[]byte{0xFF, 0xFF, 0x7F}, 2097151, 2},
+		6: {[]byte{0x81, 0x80, 0x80, 0x00}, 2097152, 3},
+		7: {[]byte{0xC0, 0x80, 0x80, 0x00}, 134217728, 3},
+		8: {[]byte{0xFF, 0xFF, 0xFF, 0x7F}, 268435455, 3},
 
-		9:  {[]byte{0x82, 0x00}, 256},
-		10: {[]byte{0x81, 0x10}, 144},
+		9:  {[]byte{0x82, 0x00}, 256, 1},
+		10: {[]byte{0x81, 0x10}, 144, 1},
 	}
 
 	for i, tc := range testCases {
 		t.Logf("test case %d - %#v\n", i, tc.input)
-		if o, _ := DecodeVarint(tc.input); o != tc.output {
+		o, size := DecodeVarint(tc.input)
+		if o != tc.output {
 			t.Fatalf("expected %d\ngot\n%d\n", tc.output, o)
+		}
+		if size != tc.size {
+			t.Fatalf("expected encoding size of %d bytes\ngot %d bytes\n", tc.size, size)
 		}
 		if encoded := EncodeVarint(tc.output); bytes.Compare(encoded, tc.input) != 0 {
 			t.Fatalf("%d - expected %#v\ngot\n%#v\n", tc.output, tc.input, encoded)

--- a/exercises/variable-length-quantity/variable_length_quantity_test.go
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.go
@@ -5,22 +5,6 @@ import (
 	"testing"
 )
 
-/*
-The goal of this exercise is to implement
-VLQ encoding/decoding as described here: https://en.wikipedia.org/wiki/Variable-length_quantity
-
-In short, the goal of this encoding is to save encode integer values in a way that would save bytes.
-Only the first 7 bits of each byte is significant (right-justified; sort of like an ASCII byte).
-So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes.
-Of course, you will have a variable number of bytes depending upon your integer.
-To indicate which is the last byte of the series, you leave bit #7 clear.
-In all of the preceding bytes, you set bit #7.
-
-So, if an integer is between `0-127`, it can be represented as one byte.
-The largest integer allowed is `0FFFFFFF`, which translates to 4 bytes variable length.
-Here are examples of delta-times as 32-bit values, and the variable length quantities that they translate to:
-*/
-
 func TestEncodeDecodeVarint(t *testing.T) {
 	testCases := []struct {
 		input  []byte


### PR DESCRIPTION
Check the second parameter during VLE tests, as discussed [here](https://github.com/exercism/xgo/pull/322)

@mattetti 
